### PR TITLE
fix : domRenderer class cleansing issue

### DIFF
--- a/engine/module/pwge/domRenderer.js
+++ b/engine/module/pwge/domRenderer.js
@@ -70,7 +70,6 @@ define("pwge/domRenderer", ["pwge/util", "util/PubSub"], function(util, PubSub){
         return this.nodes.pop();
     };
 
-
     DOMRenderer.prototype.returnRendererNode = function( node, hardReset ){
         node.reset( hardReset );
         this.nodes.push(node);

--- a/engine/module/pwge/domRenderer.js
+++ b/engine/module/pwge/domRenderer.js
@@ -64,12 +64,13 @@ define("pwge/domRenderer", ["pwge/util", "util/PubSub"], function(util, PubSub){
         }
 
         //if miss, create a node with the prop and then return it
+        this.nodes[len-1].refDOMNode.className = this.selector; //need to be reset
         this.nodes[len-1].refDOMNode.classList.add(prop);
         this.nodes[len-1].classList.push(prop);
         return this.nodes.pop();
     };
 
-   
+
     DOMRenderer.prototype.returnRendererNode = function( node, hardReset ){
         node.reset( hardReset );
         this.nodes.push(node);


### PR DESCRIPTION
domRenderer를 enable했을 경우 dom node를 재활용하게 되는데, 이 때 기존 노드의 class 들이 잔재하여 제대로 sprite들이 표시되지 않는 버그가 있습니다. 그러므로, 아래 수정사항과 같이 새로 노드를 세팅할때는 class도 리셋할 필요가 있습니다.

한정된 노드를 계속적으로 재활용하는 테스트를 하면 위에서 해당 버그가 발생하며, 이 패치를 적용한 후 발생하지 않는 것을 확인했습니다.
